### PR TITLE
Fixed issue: note create form not clearing out

### DIFF
--- a/assets/scripts/navPages.js
+++ b/assets/scripts/navPages.js
@@ -61,8 +61,8 @@ const passNoteToEditModal = function () {
   // set data-id on form so it can get passed on Save
   $('#note-edit').attr('data-id', dataId)
   // since the fieldset is appended, it needs to be cleared out so multiple field sets are not appended
-  $('fieldset').empty()
-  $('fieldset').append(noteEditFields({note: noteItem}))
+  $('#note-edit-fieldset').empty()
+  $('#note-edit-fieldset').append(noteEditFields({note: noteItem}))
 
   // manually set checkbox. checkboxes suck
   $('input[type="checkbox"]').prop('checked', noteItem.favorite)

--- a/assets/scripts/templates/note-create-modal.handlebars
+++ b/assets/scripts/templates/note-create-modal.handlebars
@@ -8,11 +8,11 @@
 
       <form id="note-create" class="form-horizontal">
         <div class="modal-body form-group">
-          <fieldset>
-            <input type="checkbox" name="note[favorite]" id="favorite">
+          <fieldset id="note-create-fieldset">
+            <input  id="note-create-favorite" type="checkbox" name="note[favorite]">
             <label for="favorite">favorite?</label>
-            <input type="text" name="note[note_title]" class="note-title" placeholder="Note title">
-            <input type="text" name="note[note_detail]" class="note-detail" placeholder="Note detail">
+            <input id="note-create-title" type="text" name="note[note_title]" class="note-title" placeholder="Note title">
+            <input id="note-create-detail"type="text" name="note[note_detail]" class="note-detail" placeholder="Note detail">
           </fieldset>
         </div>
         <div class="modal-footer">

--- a/assets/scripts/templates/note-partial.handlebars
+++ b/assets/scripts/templates/note-partial.handlebars
@@ -1,6 +1,6 @@
 <!-- note-partial begin-->
-            <input type="checkbox" name="note[favorite]" id="favorite-edit">
+            <input id="note-edit-favorite" type="checkbox" name="note[favorite]">
             <label for="favorite-edit">favorite?</label>
-            <input type="text" name="note[note_title]" class ="note-title" placeholder="Note title" value="{{note.note_title}}">
-            <input type="text" name="note[note_detail]" class="note-detail" placeholder="Note detail" value="{{note.note_detail}}">
+            <input id="note-edit-title" type="text" name="note[note_title]" class ="note-title" placeholder="Note title" value="{{note.note_title}}">
+            <input id="note-edit-detail" type="text" name="note[note_detail]" class="note-detail" placeholder="Note detail" value="{{note.note_detail}}">
 <!-- note-partial end -->

--- a/assets/scripts/templates/note-update-modal.handlebars
+++ b/assets/scripts/templates/note-update-modal.handlebars
@@ -8,7 +8,7 @@
       </div>
       <form id="note-edit" class="form-horizontal">
         <div class="modal-body form-group">
-          <fieldset>
+          <fieldset id="note-edit-fieldset">
           </fieldset>
         </div>
         <div class="modal-footer">


### PR DESCRIPTION
--Changed passNoteToEditModal so that the .empty and .append
actions were being done to a specific fieldset. I think the fieldset
was being replaced for both note edit AND note create modals.
--updated the HTML for both modals to add ids